### PR TITLE
icon spacing on launchers

### DIFF
--- a/usr/share/litecc/frontend/css/main.css
+++ b/usr/share/litecc/frontend/css/main.css
@@ -178,6 +178,7 @@ top: 0;
 	height: 38px;
 	width: 38px;
 	float: right;
+	padding-right: 10px;
 }
 [dir=ltr] .launcher img { float: left; }
 .launcher:hover img {


### PR DESCRIPTION
It's set at 10px, @linuxlite you can tweak if you think its to much space.