### PR TITLE
reliable update check method

### DIFF
--- a/usr/share/litecc/scripts/updates
+++ b/usr/share/litecc/scripts/updates
@@ -1,5 +1,5 @@
 #!/bin/bash
-UPFILE="/var/lib/apt/periodic/update-success-stamp"
+UPFILE="/var/cache/apt/pkgcache.bin"
 
 update_status() {
 


### PR DESCRIPTION
Previous method depended on a trigger from apt, its a known bug.